### PR TITLE
Add basic FITS writer using ASTROPY library

### DIFF
--- a/Source/frames.py
+++ b/Source/frames.py
@@ -36,12 +36,13 @@ from math import ceil
 from numpy import max as np_max
 from numpy import min as np_min
 from numpy import uint8, uint16, float32, clip, zeros, float64, where, average, \
-    frombuffer, dtype
+    frombuffer, dtype, moveaxis
 
 from configuration import Configuration
 from exceptions import TypeError, ShapeError, ArgumentError, WrongOrderingError, Error, \
     InternalError
 from frames_old import FramesOld
+from astropy.io import fits
 
 
 class VideoReader(object):
@@ -1308,9 +1309,13 @@ class Frames(object):
         # the BGR representation assumed by OpenCV.
         if color:
             imwrite(str(filename), cvtColor(image, COLOR_RGB2BGR))
+            hdu = fits.PrimaryHDU(moveaxis(cvtColor(image, COLOR_RGB2BGR), -1, 0))
         else:
             imwrite(str(filename), image)
+            hdu = fits.PrimaryHDU(image)
 
+        hdu.header['CREATOR'] = 'PlanetarySystemStacker'
+        hdu.writeto(str(filename.replace('.tiff', '.fits')), overwrite=True)
 
 def access_pattern(frames_object, average_frame_percent):
     """


### PR DESCRIPTION
Hi Rolf,

If You want to include the "FITS" file format for saving the stacked file, this can be done in a quite simple way using "astropy" library: https://www.astropy.org . Additionally, we can add the functionality to save RGB channels as seperate FITS files for the color image...

Best regards
Michal