### PR TITLE
Prototype

### DIFF
--- a/Source/alignment_point_editor.py
+++ b/Source/alignment_point_editor.py
@@ -717,7 +717,7 @@ class AlignmentPointEditorWidget(QtWidgets.QFrame, Ui_alignment_point_editor):
 
         # If the mean frame type is not uint8, values correspond to 16bit resolution.
         if align_frames.mean_frame.dtype != uint8:
-            self.mean_frame = align_frames.mean_frame[:,:]/256.
+            self.mean_frame = align_frames.mean_frame / 256
         else:
             self.mean_frame = align_frames.mean_frame
 

--- a/Source/frames.py
+++ b/Source/frames.py
@@ -32,13 +32,13 @@ from PyQt5 import QtCore
 from cv2 import imread, VideoCapture, CAP_PROP_FRAME_COUNT, cvtColor, COLOR_BGR2GRAY, \
     COLOR_RGB2GRAY, COLOR_BGR2RGB, GaussianBlur, Laplacian, CV_32F, COLOR_RGB2BGR, imwrite, \
     convertScaleAbs, CAP_PROP_POS_FRAMES, IMREAD_GRAYSCALE, IMREAD_UNCHANGED, \
-    COLOR_BayerRG2RGB, COLOR_BayerGR2RGB, COLOR_BayerGB2RGB, COLOR_BayerBG2RGB
+    COLOR_BayerRG2RGB, COLOR_BayerGR2RGB, COLOR_BayerGB2RGB, COLOR_BayerBG2RGB, flip
 from cv2 import mean as cv_mean
 from math import ceil
 from numpy import max as np_max
 from numpy import min as np_min
 from numpy import uint8, uint16, float32, clip, zeros, float64, where, average, \
-    frombuffer, dtype, moveaxis, flip
+    frombuffer, dtype, moveaxis
 
 from configuration import Configuration
 from exceptions import TypeError, ShapeError, ArgumentError, WrongOrderingError, Error, \
@@ -1343,10 +1343,12 @@ class Frames(object):
                 imwrite(str(filename), image)
 
         elif Path(filename).suffix == '.fits':
+            # Flip image horizontally to preserve orientation
             if color:
-                hdu = fits.PrimaryHDU(moveaxis(cvtColor(image, COLOR_RGB2BGR), -1, 0))
+                image = moveaxis(flip(image, 0), -1, 0)
             else:
-                hdu = fits.PrimaryHDU(image)
+                image = flip(image, axis=0)
+            hdu = fits.PrimaryHDU(image)
             hdu.header['CREATOR'] = 'PlanetarySystemStacker'
             hdu.writeto(filename, overwrite=True)
 
@@ -1383,7 +1385,7 @@ class Frames(object):
                 image = moveaxis(image, 0, -1).copy()
 
             # Flip image horizontally to recover orignal orientation
-            image = flip(image, axis=0)
+            image = flip(image, 0)
 
         # Case other supported image formats:
         elif suffix == '.tiff' or suffix == '.tif' or suffix == '.png' or suffix == '.jpg':

--- a/Source/frames.py
+++ b/Source/frames.py
@@ -1347,7 +1347,7 @@ class Frames(object):
             if color:
                 image = moveaxis(flip(image, 0), -1, 0)
             else:
-                image = flip(image, axis=0)
+                image = flip(image, 0)
             hdu = fits.PrimaryHDU(image)
             hdu.header['CREATOR'] = 'PlanetarySystemStacker'
             hdu.writeto(filename, overwrite=True)

--- a/Source/frames.py
+++ b/Source/frames.py
@@ -1368,8 +1368,11 @@ class Frames(object):
         suffix = suffix.lower()
 
         # Case FITS format:
-        if suffix == '.fits':
-            image = moveaxis(fits.getdata(filename, ext=0), 0, -1).copy()
+        if suffix == '.fit' or suffix == '.fits':
+            image = fits.getdata(filename)
+            # If color image, move axis to be able to process the content
+            if len(image.shape) == 3:
+                image = moveaxis(image, 0, -1).copy()
 
         # Case other supported image formats:
         elif suffix == '.tiff' or suffix == '.tif' or suffix == '.png' or suffix == '.jpg':
@@ -1383,7 +1386,7 @@ class Frames(object):
 
         else:
             raise TypeError("Attempt to read image format other than 'tiff', 'tif',"
-                            " '.png', '.jpg' or 'fits'")
+                            " '.png', '.jpg' or 'fit', 'fits'")
 
         return image
 

--- a/Source/miscellaneous.py
+++ b/Source/miscellaneous.py
@@ -57,8 +57,8 @@ class Miscellaneous(object):
         """
 
         # Compute for each point the local gradient in both coordinate directions.
-        dx = diff(frame)[:, :]
-        dy = diff(frame, axis=0)[:, :]
+        dx = diff(frame)
+        dy = diff(frame, axis=0)
 
         # Compute the sharpness per coordinate direction as the 1-norm of point values.
         sharpness_x = average(np_abs(dx))
@@ -103,7 +103,7 @@ class Miscellaneous(object):
         stride_2 = 2 * stride
 
         # Compute a mask for all pixels which are bright enough (to avoid background noise).
-        mask = frame[:, :] > black_threshold
+        mask = frame > black_threshold
         mask_fraction = mask.sum() / frame_size
 
         # If most pixels are bright enough, compensate for different pixel counts.

--- a/Source/rectangular_patch_editor.py
+++ b/Source/rectangular_patch_editor.py
@@ -370,7 +370,7 @@ class RectangularPatchEditorWidget(QtWidgets.QFrame, Ui_rectangular_patch_editor
         # Convert the frame into uint8 format. If the frame type is uint16, values
         # correspond to 16bit resolution.
         if frame.dtype == uint16 or frame.dtype == int32:
-            self.frame = (frame[:, :] / 256.).astype(uint8)
+            self.frame = (frame / 256).astype(uint8)
         elif frame.dtype == uint8:
             self.frame = frame
         else:

--- a/Source/workflow.py
+++ b/Source/workflow.py
@@ -360,13 +360,6 @@ class Workflow(QtCore.QObject):
             # Convert 8 bit to 16 bit.
             if self.postproc_input_image.dtype == uint8:
                 self.postproc_input_image = self.postproc_input_image.astype(uint16) * 256
-
-            # FITS output file from AS3 is 16bit depth file, even though BITPIX
-            # has been set to "-32", which would suggest "numpy.float32"
-            # https://docs.astropy.org/en/stable/io/fits/usage/image.html
-            # To process this data in PSS, do "round()" and convert numpy array to "np.uint16"
-            elif self.postproc_input_image.dtype == '>f4':
-                self.postproc_input_image = self.postproc_input_image.round().astype(uint16)
             self.work_next_task_signal.emit("Postprocessing")
 
     @QtCore.pyqtSlot()

--- a/Source/workflow.py
+++ b/Source/workflow.py
@@ -360,6 +360,13 @@ class Workflow(QtCore.QObject):
             # Convert 8 bit to 16 bit.
             if self.postproc_input_image.dtype == uint8:
                 self.postproc_input_image = self.postproc_input_image.astype(uint16) * 256
+
+            # FITS output file from AS3 is 16bit depth file, even though BITPIX
+            # has been set to "-32", which would suggest "numpy.float32"
+            # https://docs.astropy.org/en/stable/io/fits/usage/image.html
+            # To process this data in PSS, do "round()" and convert numpy array to "np.uint16"
+            elif self.postproc_input_image.dtype == '>f4':
+                self.postproc_input_image = self.postproc_input_image.round().astype(uint16)
             self.work_next_task_signal.emit("Postprocessing")
 
     @QtCore.pyqtSlot()

--- a/Source/workflow.py
+++ b/Source/workflow.py
@@ -29,9 +29,7 @@ from os.path import splitext, join
 import gc
 import psutil
 from PyQt5 import QtCore
-from cv2 import imread, cvtColor, COLOR_BGR2RGB, COLOR_GRAY2RGB, COLOR_RGB2GRAY
-from numpy import uint16, uint8, ndarray, moveaxis
-from astropy.io import fits
+from numpy import uint16, uint8
 
 from align_frames import AlignFrames
 from alignment_points import AlignmentPoints


### PR DESCRIPTION
Hi Rolf,
I spent some time fine-tunning the FITS support in PSS. In case of "moveaxis()", the Numpy doc is saying, that the "view" is return value - this might be the reason, why the ".copy()" needs to be used. QT might expect propper "array" and propably cannot deal with the "view",  and crashes as the result.
/ Michal
