### PR TITLE
explicit memory maximum logic

### DIFF
--- a/planetary_system_stacker/configuration.py
+++ b/planetary_system_stacker/configuration.py
@@ -25,6 +25,8 @@ from configparser import ConfigParser
 from copy import deepcopy
 from os.path import expanduser, join, isfile, dirname
 from os.path import splitext
+
+import psutil
 from numpy import uint8
 
 from exceptions import ArgumentError
@@ -49,6 +51,8 @@ class ConfigurationParameters(object):
         self.global_parameters_write_protocol_to_file = None
         self.global_parameters_store_protocol_with_result = None
         self.global_parameters_buffering_level = None
+        self.global_parameters_maximum_memory_active = None
+        self.global_parameters_maximum_memory_amount = None
         self.global_parameters_include_postprocessing = None
         self.global_parameters_image_format = None
         self.global_parameters_parameters_in_filename = None
@@ -89,6 +93,9 @@ class ConfigurationParameters(object):
         self.global_parameters_write_protocol_to_file = False
         self.global_parameters_store_protocol_with_result = False
         self.global_parameters_buffering_level = -1
+        self.global_parameters_maximum_memory_active = False
+        self.global_parameters_maximum_memory_amount = \
+            max(1, int(dict(psutil.virtual_memory()._asdict())['available'] / 1e9))
         self.global_parameters_include_postprocessing = True
         self.global_parameters_image_format = "png"
         self.global_parameters_parameters_in_filename = False
@@ -142,6 +149,10 @@ class ConfigurationParameters(object):
             configuration_object.global_parameters_store_protocol_with_result
         self.global_parameters_buffering_level = \
             configuration_object.global_parameters_buffering_level
+        self.global_parameters_maximum_memory_active = \
+            configuration_object.global_parameters_maximum_memory_active
+        self.global_parameters_maximum_memory_amount = \
+            configuration_object.global_parameters_maximum_memory_amount
         self.global_parameters_include_postprocessing = \
             configuration_object.global_parameters_include_postprocessing
         self.global_parameters_image_format = \
@@ -334,6 +345,10 @@ class Configuration(object):
             configuration_parameters.global_parameters_store_protocol_with_result
         self.global_parameters_buffering_level = \
             configuration_parameters.global_parameters_buffering_level
+        self.global_parameters_maximum_memory_active = \
+            configuration_parameters.global_parameters_maximum_memory_active
+        self.global_parameters_maximum_memory_amount = \
+            configuration_parameters.global_parameters_maximum_memory_amount
         self.global_parameters_include_postprocessing = \
             configuration_parameters.global_parameters_include_postprocessing
         self.global_parameters_image_format = \
@@ -495,6 +510,10 @@ class Configuration(object):
             'store protocol with result', default_conf_obj.global_parameters_store_protocol_with_result)
         self.global_parameters_buffering_level = get_from_conf(conf, 'Global parameters',
             'buffering level', default_conf_obj.global_parameters_buffering_level)
+        self.global_parameters_maximum_memory_active = get_from_conf(conf, 'Global parameters',
+            'maximum memory active', default_conf_obj.global_parameters_maximum_memory_active)
+        self.global_parameters_maximum_memory_amount = get_from_conf(conf, 'Global parameters',
+            'maximum memory amount', default_conf_obj.global_parameters_maximum_memory_amount)
         self.global_parameters_include_postprocessing = get_from_conf(conf, 'Global parameters',
             'include postprocessing', default_conf_obj.global_parameters_include_postprocessing)
         self.global_parameters_image_format = get_from_conf(conf, 'Global parameters',
@@ -590,6 +609,10 @@ class Configuration(object):
                            str(self.global_parameters_store_protocol_with_result))
         self.set_parameter('Global parameters', 'buffering level',
                            str(self.global_parameters_buffering_level))
+        self.set_parameter('Global parameters', 'maximum memory active',
+                           str(self.global_parameters_maximum_memory_active))
+        self.set_parameter('Global parameters', 'maximum memory amount',
+                           str(self.global_parameters_maximum_memory_amount))
         self.set_parameter('Global parameters', 'include postprocessing',
                            str(self.global_parameters_include_postprocessing))
         self.set_parameter('Global parameters', 'image format',

--- a/planetary_system_stacker/configuration_editor.py
+++ b/planetary_system_stacker/configuration_editor.py
@@ -324,14 +324,14 @@ class ConfigurationEditor(QtWidgets.QFrame, Ui_ConfigurationDialog):
         self.mr_lineEdit.setEnabled(False)
 
     def mr_changed(self, state):
-        explicit_memory_on = (state == QtCore.Qt.Checked)
-        if explicit_memory_on:
-            if explicit_memory_on != self.config_copy.global_parameters_maximum_memory_active:
+        max_memory_active = (state == QtCore.Qt.Checked)
+        if max_memory_active:
+            if max_memory_active != self.config_copy.global_parameters_maximum_memory_active:  # Only dialog on change
                 warning = ExplicitMemoryWarning()
                 if warning.exec():
                     self.mr_activate()
                 else:
-                    self.mr_checkBox.setCheckState(QtCore.Qt.Unchecked)
+                    self.mr_checkBox.setCheckState(QtCore.Qt.Unchecked)  # Go back to unchecked if cancelled
             else:
                 self.mr_activate()
         else:

--- a/planetary_system_stacker/configuration_editor.py
+++ b/planetary_system_stacker/configuration_editor.py
@@ -339,7 +339,7 @@ class ConfigurationEditor(QtWidgets.QFrame, Ui_ConfigurationDialog):
             self.mr_deactivate()
 
     def mr_text_changed(self, state):
-        if state != '' and int(state) != 0:
+        if state != '' and int(state) > 0:
             self.config_copy.global_parameters_maximum_memory_amount = state
 
     def gpif_changed(self, value):

--- a/planetary_system_stacker/configuration_editor.py
+++ b/planetary_system_stacker/configuration_editor.py
@@ -314,7 +314,7 @@ class ConfigurationEditor(QtWidgets.QFrame, Ui_ConfigurationDialog):
 
     def mr_activate(self):
         self.config_copy.global_parameters_maximum_memory_active = True
-        self.gpbl_combobox.setCurrentIndex(0)  # set buffering to 'auto'
+        self.gpbl_combobox.setCurrentText('auto')  # With a fixed memory limit buffering is set to 'auto'
         self.gpbl_combobox.setEnabled(False)
         self.mr_lineEdit.setEnabled(True)
 

--- a/planetary_system_stacker/configuration_editor.py
+++ b/planetary_system_stacker/configuration_editor.py
@@ -671,7 +671,7 @@ class ExplicitMemoryWarning(QDialog):
     def __init__(self):
         super().__init__()
 
-        self.setWindowTitle("Explicit memory activation warning!")
+        self.setWindowTitle("Memory limit warning")
 
         self.buttonBox = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
         self.buttonBox.accepted.connect(self.accept)

--- a/planetary_system_stacker/configuration_editor.py
+++ b/planetary_system_stacker/configuration_editor.py
@@ -314,7 +314,6 @@ class ConfigurationEditor(QtWidgets.QFrame, Ui_ConfigurationDialog):
 
     def mr_activate(self):
         self.config_copy.global_parameters_maximum_memory_active = True
-        self.config_copy.global_parameters_buffering_level = -1
         self.gpbl_combobox.setCurrentIndex(0)  # set buffering to 'auto'
         self.gpbl_combobox.setEnabled(False)
         self.mr_lineEdit.setEnabled(True)

--- a/planetary_system_stacker/configuration_editor.py
+++ b/planetary_system_stacker/configuration_editor.py
@@ -338,8 +338,12 @@ class ConfigurationEditor(QtWidgets.QFrame, Ui_ConfigurationDialog):
             self.mr_deactivate()
 
     def mr_text_changed(self, state):
-        if state != '' and int(state) > 0:
-            self.config_copy.global_parameters_maximum_memory_amount = state
+        try:
+            memory_amount = int(state)
+            if memory_amount > 0:
+                self.config_copy.global_parameters_maximum_memory_amount = memory_amount
+        except ValueError:
+            return
 
     def gpif_changed(self, value):
         self.config_copy.global_parameters_image_format = value

--- a/planetary_system_stacker/configuration_editor.py
+++ b/planetary_system_stacker/configuration_editor.py
@@ -96,7 +96,7 @@ class ConfigurationEditor(QtWidgets.QFrame, Ui_ConfigurationDialog):
         self.gpbl_combobox.addItem('4')
         self.gpbl_combobox.activated[str].connect(self.gpbl_changed)
         self.mr_checkBox.stateChanged.connect(self.mr_changed)
-        self.mr_lineEdit.setValidator(QIntValidator())
+        self.mr_lineEdit.setValidator(QIntValidator(1, 2147483647))
         self.mr_lineEdit.textChanged.connect(self.mr_text_changed)
         self.gpif_comboBox.addItem('png')
         self.gpif_comboBox.addItem('tiff')
@@ -339,9 +339,7 @@ class ConfigurationEditor(QtWidgets.QFrame, Ui_ConfigurationDialog):
 
     def mr_text_changed(self, state):
         try:
-            memory_amount = int(state)
-            if memory_amount > 0:
-                self.config_copy.global_parameters_maximum_memory_amount = memory_amount
+            self.config_copy.global_parameters_maximum_memory_amount = int(state)
         except ValueError:
             return
 

--- a/planetary_system_stacker/configuration_editor.py
+++ b/planetary_system_stacker/configuration_editor.py
@@ -678,7 +678,8 @@ class ExplicitMemoryWarning(QDialog):
         self.buttonBox.rejected.connect(self.reject)
 
         self.layout = QVBoxLayout()
-        message = QLabel("Setting the memory limit too high may cause degraded OS performance and/or process crashes")
+        message = QLabel("PlanetarySystemStacker takes no responsibility for enough memory being available.\r\n"
+                         "Setting the memory limit too high may cause degraded OS performance and/or process crashes")
         self.layout.addWidget(message)
         self.layout.addWidget(self.buttonBox)
         self.setLayout(self.layout)

--- a/planetary_system_stacker/workflow.py
+++ b/planetary_system_stacker/workflow.py
@@ -274,9 +274,12 @@ class Workflow(QtCore.QObject):
                 Miscellaneous.print_stacking_parameters(self.configuration, self.attached_log_file)
 
             try:
-                # Look up the available RAM (without paging)
-                virtual_memory = dict(psutil.virtual_memory()._asdict())
-                available_ram = virtual_memory['available'] / 1e9
+                if self.configuration.global_parameters_maximum_memory_active:
+                    available_ram = float(self.configuration.global_parameters_maximum_memory_amount)
+                else:
+                    # Look up the available RAM (without paging)
+                    virtual_memory = dict(psutil.virtual_memory()._asdict())
+                    available_ram = virtual_memory['available'] / 1e9
 
                 self.frames = Frames(self.configuration, names, type=self.job.type,
                                      bayer_option_selected=self.job.bayer_option_selected,


### PR DESCRIPTION
For issue https://github.com/Rolf-Hempel/PlanetarySystemStacker/issues/50
- Defaults to limit max(1,"available")
- Only tested by running the application so far.
- Currently allows full GB increments only, Initially I tried to use QDoubleValidator for the GBs, but that had quite confusing behavior related to comma vs dot separators. It would show 5.0 (with a dot), but then refuse to accept dots as input since my locale uses commas. So I went with the QIntValidator. For my use and for most I think this is sufficient, what do you think? A regexp string validation is another option.